### PR TITLE
fix: testhandle test false

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ install_requires =
     dateparser
     pytest
     packaging
+    numpy<=1.24 # Numpy does not support 3.8 if above 1.24
+    urllib3<2.0.0
 
 [options.packages.find]
 where=src

--- a/src/spetlrtools/testing/TestHandle.py
+++ b/src/spetlrtools/testing/TestHandle.py
@@ -5,6 +5,8 @@ from spetlr.tables.TableHandle import TableHandle
 
 
 class TestHandle(TableHandle):
+    __test__ = False  # solves PytestCollectionWarning
+
     def __init__(self, provides: DataFrame = None):
         self.provides = provides
         self.overwritten = None


### PR DESCRIPTION
The testhandle gives an PytestCollectionWarning. The pytest reads the "Test"-part of the handle name.

`__test__ = false` solves this issue.

Updated package dependencies due to no 3.8 python support:
* numpy

Updated package dependency due to databricks cli requirement:
* urllib