### PR TITLE
fix: wait 1 minute for test setup

### DIFF
--- a/src/spetlrtools/test_job/submit.py
+++ b/src/spetlrtools/test_job/submit.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 import uuid
 from pathlib import Path
 from typing import Dict, List, Union
@@ -351,6 +352,11 @@ def submit(
                 )
             )
 
+    print("Wait 1 minute for uploading test folder...")
+    time.sleep(secs=60)
+    print("Waited 1 minute successfully!")
+
+    print("Submitting test...")
     with tempfile.TemporaryDirectory() as tmp:
         jobfile = f"{tmp}/job.json"
         with open(jobfile, "w") as f:


### PR DESCRIPTION
Sometimes, when using spetlr submit test tools, the path for the test library cannot be found.

It is expected, that the files simply have not been uploaded before executing.

This is a quick fix, and the issue should be solved more robustly later.

After uploading the test files, a 1 minute wait is introduced, to ensure that the file exists before running `databricks run submit`