### PR TITLE
Feature/diagram tool blind to whitespace

### DIFF
--- a/src/spetlrtools/diagrams/DiagramMarkupLibraryParser.py
+++ b/src/spetlrtools/diagrams/DiagramMarkupLibraryParser.py
@@ -57,6 +57,13 @@ class DiagramMarkupLibraryParser:
                 print(f"WARNING: block in {file_path} is not a dict")
                 continue
             for key, node in obj.items():
+                if not isinstance(node, dict):
+                    print(f"WARNING: The contents of {key} are not a dict: {node}.")
+                    print("         If you want a simple alias use:")
+                    print(f"           {key}:")
+                    print(f"           name: {node}")
+                    continue
+
                 try:
                     node["name"] = condense_whitespace(node["name"])
                 except KeyError:

--- a/src/spetlrtools/diagrams/DiagramMarkupLibraryParser.py
+++ b/src/spetlrtools/diagrams/DiagramMarkupLibraryParser.py
@@ -6,6 +6,7 @@ from typing import List
 import yaml
 
 from spetlrtools.diagrams.Edge import Edge
+from spetlrtools.diagrams.HTMLStripper import condense_whitespace
 
 
 class DiagramDefinitionError(Exception):
@@ -57,7 +58,7 @@ class DiagramMarkupLibraryParser:
                 continue
             for key, node in obj.items():
                 try:
-                    _ = node["name"]
+                    node["name"] = condense_whitespace(node["name"])
                 except KeyError:
                     print(f"WARNING: Missing name in node {key} of {file_path}")
                     continue

--- a/src/spetlrtools/diagrams/DrawioDiagramParser.py
+++ b/src/spetlrtools/diagrams/DrawioDiagramParser.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from urllib.parse import unquote
 
 from spetlrtools.diagrams.Edge import Edge
-from spetlrtools.diagrams.HTMLStripper import HTMLStripper
+from spetlrtools.diagrams.HTMLStripper import HTMLStripper, condense_whitespace
 
 
 class DiagramNode:
@@ -46,7 +46,10 @@ class DiagramEdge(DiagramNode):
         return f"< {self.source_label} -- {self.target_label} >"
 
     def get_Edge(self) -> Edge:
-        return Edge(self.source_label, self.target_label)
+        return Edge(
+            condense_whitespace(self.source_label),
+            condense_whitespace(self.target_label),
+        )
 
 
 class DrawioDiagramParser:

--- a/src/spetlrtools/diagrams/HTMLStripper.py
+++ b/src/spetlrtools/diagrams/HTMLStripper.py
@@ -1,3 +1,4 @@
+import re
 from html.parser import HTMLParser
 from io import StringIO
 
@@ -28,3 +29,9 @@ class HTMLStripper(HTMLParser):
         o = HTMLStripper()
         o.feed(text)
         return o.get_data()
+
+
+def condense_whitespace(input: str) -> str:
+    """The output has all whitespace sequences replaces with a single space.
+    Leading and trailing whitespaces are stripped."""
+    return re.sub(r"\s+", " ", input).strip()


### PR DESCRIPTION
- The diagram tool would previously not recognize the equality of edges that differ in whitespace. This has been remedied. 
- The diagram tool now gives better error messages in the case that a name:alias is missing the space after the colon