### PR TITLE
all version locks removed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,14 +33,14 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     spetlr
-    pyyaml==6.0
+    pyyaml
     importlib_metadata
-    requests<2.29.0,>=2.28.1  # required by databricks-sdk
+    requests
     dateparser
     pytest
     packaging
-    numpy<=1.24 # Numpy does not support 3.8 if above 1.24
-    urllib3<2.0.0
+    numpy
+    urllib3
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
version locks should be up to the end-user to enforce