### PR TITLE
improve nullability clearing in schema comparison

### DIFF
--- a/src/spetlrtools/testing/DataframeTestCase.py
+++ b/src/spetlrtools/testing/DataframeTestCase.py
@@ -92,6 +92,12 @@ class DataframeTestCase(unittest.TestCase):
                 if field["type"] == "struct":
                     for item in field["fields"]:
                         clear_nullable(item)
+                elif (
+                    field["type"] == "array"
+                    and field["elementType"]["type"] == "struct"
+                ):
+                    for item in field["elementType"]["fields"]:
+                        clear_nullable(item)
 
             for j in [json1, json2]:
                 for item in j["fields"]:


### PR DESCRIPTION
the old implementation did not clear the member nullability of array of structs.