### PR TITLE
Feature/test job cli v2

### DIFF
--- a/src/spetlrtools/test_job/dbcli.py
+++ b/src/spetlrtools/test_job/dbcli.py
@@ -1,65 +1,81 @@
 import json
+import re
 import subprocess
 import sys
 
 
-def db_check():
-    """check that the databricks cli is correctly configured
-    and has an up-to-date authorization token.
-    Returns Nothing.
-    Ends the program if this check fails."""
-    try:
-        import databricks_cli  # noqa
-    except ImportError:
-        print("Databricks CLI is not installed", file=sys.stderr)
-        exit(-1)
-
-    try:
-        dbjcall("clusters list  --output=JSON")
-    except subprocess.CalledProcessError:
-        print(
-            "Could not query databricks state. Is your token up to date?",
-            file=sys.stderr,
+class DbCli:
+    def __init__(self):
+        # establish databricks cli versrion
+        version_string = subprocess.check_output(
+            ["databricks", "--version"], encoding="utf-8"
         )
-        exit(-1)
-    dbcall("jobs configure --version=2.1")
+        match = re.match(r".*[^.0-9](\d+)\.(\d+)\.(\d+).*", version_string)
+        version_tuple = int(match.group(1)), int(match.group(2)), int(match.group(3))
+        if version_tuple < (0, 19, 0):
+            self.version = 1
+        else:
+            self.version = 2
+
+        if self.version == 1:
+            self.dbjcall("jobs configure --version=2.1")
+
+    def dbjcall(self, command: str):
+        """Run the command line "databricks "+command and return the unpacked json string."""
+        res = self.dbcall(command)
+        try:
+            if res:
+                return json.loads(res)
+            else:
+                return None
+        except:  # noqa OK because we re-raise
+            print(res)
+            raise
+
+    def check_connection(self):
+        try:
+            self.dbjcall("clusters list  --output=JSON")
+        except subprocess.CalledProcessError:
+            print(
+                "Could not query databricks state. Is your token up to date?",
+                file=sys.stderr,
+            )
+            exit(-1)
+
+    def dbcall(self, command: str):
+        """Run the command line "databricks "+command and return the resulting string."""
+        p = subprocess.run(
+            "databricks " + command,
+            shell=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        return p.stdout
+
+    def cancel_run(self, run_id: int):
+        if self.version == 1:
+            return self.dbcall(f"runs cancel --run-id {run_id}")
+        else:
+            return self.dbcall(f"jobs cancel_run {run_id}")
+
+    def get_run(self, run_id: int):
+        if self.version == 1:
+            return self.dbjcall(f"runs get --run-id {run_id}")
+        else:
+            return self.dbjcall(f"jobs get-run {run_id}")
+
+    def list_instance_pools(self):
+        if self.version == 1:
+            return self.dbjcall("instance-pools list --output JSON")["instance_pools"]
+        else:
+            return self.dbjcall("instance-pools list --output JSON")
+
+    def submit_run_file(self, file_path: str):
+        if self.version == 1:
+            return self.dbjcall(f"runs submit --json-file {file_path}")
+        else:
+            return self.dbjcall(f"jobs submit --no-wait --json @{file_path}")
 
 
-def dbjcall(command: str):
-    """Run the command line "databricks "+command and return the unpacked json string."""
-    p = subprocess.run(
-        "databricks " + command,
-        shell=True,
-        stdout=subprocess.PIPE,
-        check=True,
-        text=True,
-    )
-    try:
-        return json.loads(p.stdout)
-    except:  # noqa OK because we re-raise
-        print(p.stdout)
-        raise
-
-
-def dbfscall(command: str):
-    """Run the command line "dbfs "+command and return the output string."""
-    p = subprocess.run(
-        "dbfs " + command,
-        shell=True,
-        stdout=subprocess.PIPE,
-        check=True,
-        text=True,
-    )
-    return p.stdout
-
-
-def dbcall(command: str):
-    """Run the command line "databricks "+command and return the resulting string."""
-    p = subprocess.run(
-        "databricks " + command,
-        shell=True,
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
-    return p.stdout
+dbcli = DbCli()

--- a/src/spetlrtools/test_job/dbcli.py
+++ b/src/spetlrtools/test_job/dbcli.py
@@ -7,9 +7,13 @@ import sys
 class DbCli:
     def __init__(self):
         # establish databricks cli versrion
-        version_string = subprocess.check_output(
-            ["databricks", "--version"], encoding="utf-8"
-        )
+        try:
+            version_string = subprocess.check_output(
+                ["databricks", "--version"], encoding="utf-8"
+            )
+        except FileNotFoundError:
+            # in case of missing executable, assume v1
+            version_string = "Databricks CLI v0.210.1"
         match = re.match(r".*[^.0-9](\d+)\.(\d+)\.(\d+).*", version_string)
         version_tuple = int(match.group(1)), int(match.group(2)), int(match.group(3))
         if version_tuple < (0, 19, 0):

--- a/src/spetlrtools/test_job/fetch.py
+++ b/src/spetlrtools/test_job/fetch.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import IO, List, Optional
 
-from spetlrtools.test_job.dbcli import db_check
+from spetlrtools.test_job.dbcli import dbcli
 from spetlrtools.test_job.RunDetails import RunDetails
 
 
@@ -72,7 +72,7 @@ def fetch_main(args):
     :param args: the parsed arguments from the fetch subparser
     :return:
     """
-    db_check()
+    dbcli.check_connection()
 
     # Post process the arguments
     if args.runid is None:


### PR DESCRIPTION
This PR makes the test job submission and fetch scripts compatible with both the databricks cli v1 and v2, adapting automatically.

To test, I have installed this branch and executed the test submission in a project using the cli v2 and the cli v1. Both tests gave identical results.