### PR TITLE
fix: cli install on windows

### DIFF
--- a/src/spetlrtools/cli_install/defaults.py
+++ b/src/spetlrtools/cli_install/defaults.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 
 def isWin():
-    return bool(re.match(".*windows.*", platform.system()))
+    return bool(re.match(".*windows.*", platform.system(), flags=re.IGNORECASE))
 
 
 _DEFAULT_TARGET = Path(sysconfig.get_paths()["scripts"]) / (


### PR DESCRIPTION
The windows target name was not correctly determined when the system name was "Windows".
Fixed now.