### PR TITLE
feat: use python 3.10 and java 12

### DIFF
--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Manipulate version
         run: |
           pip install packaging

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v2
         # this workflow needs java so that it can run a local instance of spark
         with:
-          java-version: '8'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.9"
+          - "3.10"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       
       - name: Install test requirements
         run: pip install -r test_requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Manipulate version
         run: |
           pip install packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
     Intended Audience :: Developers
     Topic :: Software Development :: Build Tools
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
@@ -30,7 +30,7 @@ include_package_data = True
 package_dir=
     =src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires =
     spetlr
     pyyaml

--- a/tests/unit/test_requiements.py
+++ b/tests/unit/test_requiements.py
@@ -7,16 +7,13 @@ class RequirementsTest(unittest.TestCase):
     def test_function(self):
         freeze = spetlrtools.requirements.freeze_req(
             """
-            backports.zoneinfo >= 0.1
-
-            # comment here
             pytest
             """,
             reject="pip",
         )
         deps = {lib["name"]: lib["version"] for lib in freeze}
 
-        self.assertIn("backports.zoneinfo", deps)
         self.assertIn("pytest", deps)
         self.assertIn("iniconfig", deps)
-        self.assertTrue("pip" not in deps)
+        self.assertIn("pluggy", deps)
+        self.assertNotIn("pip", deps)


### PR DESCRIPTION
# Overview

The compatibility between pyspark and python needs to be aligned

From the pyspark documentation 3.9 and above is supported: https://spark.apache.org/docs/latest/api/python/getting_started/install.html