### PR TITLE
allow fetch after re-run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 25.1.0
     hooks:
     - id: black
       language_version: python3.10
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
     - id: flake8
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)

--- a/src/spetlrtools/test_job/RunDetails.py
+++ b/src/spetlrtools/test_job/RunDetails.py
@@ -33,7 +33,7 @@ class RunDetails:
         # this allows fetch to succeed in case a "repair" fixed a transient task failure
         tasks_for_key = (t for t in self.details.tasks if t.task_key == task_key)
         # sort by negative attempt number
-        task = sorted(tasks_for_key,key=lambda t:-t.attempt_number)[0]
+        task = sorted(tasks_for_key, key=lambda t: -t.attempt_number)[0]
 
         task_id = task.run_id
         output = self._db.get_run_output(task_id)

--- a/src/spetlrtools/test_job/RunDetails.py
+++ b/src/spetlrtools/test_job/RunDetails.py
@@ -28,7 +28,13 @@ class RunDetails:
 
         print(f"Getting stdout for {task_key}")
         task: jobs.RunTask
-        (task,) = [t for t in self.details.tasks if t.task_key == task_key]
+
+        # get latest attempt for all tasks of this key
+        # this allows fetch to succeed in case a "repair" fixed a transient task failure
+        tasks_for_key = (t for t in self.details.tasks if t.task_key == task_key)
+        # sort by negative attempt number
+        task = sorted(tasks_for_key,key=lambda t:-t.attempt_number)[0]
+
         task_id = task.run_id
         output = self._db.get_run_output(task_id)
         return output.logs

--- a/tests/unit/test_testJobTools.py
+++ b/tests/unit/test_testJobTools.py
@@ -133,6 +133,7 @@ class JobSumitToolTest(unittest.TestCase):
             tasks=[
                 jobs.RunTask(
                     task_key="yo_momma",
+                    attempt_number=1,
                     state=jobs.RunState(
                         life_cycle_state=jobs.RunLifeCycleState.TERMINATED,
                         result_state=jobs.RunResultState.SUCCESS,


### PR DESCRIPTION
Some tests fail for reasons unrelated to the code. Calling "Repair run" can fix these. With this PR, the fetch script now only checks the latest attempt at each task and allows the fetch to succeed if the latest attempt succeeded